### PR TITLE
fix: Removing default suffix from password label

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -20,6 +20,7 @@ class OrgForm(forms.ModelForm):
             'Your password must: <ul id="password-specification"><li>Be longer than 8 characters</li><li>Have an uppercase and lowercase characters</li><li>Use a special character/number</li></ul>'
         ),
     )
+    password.label_suffix = ""
     confirm_password = forms.CharField(widget=forms.PasswordInput())
 
     class Meta:


### PR DESCRIPTION
Fixes issue #4 
Removing default suffix from password label to remove ':' that is out of place.

Now looks like this:

<img width="784" alt="image" src="https://github.com/kurealnum/non-profit-link/assets/9667945/4bb7ba25-cf71-4742-b6ca-a1e737ee1539">
